### PR TITLE
Mortgage Payments entries should be Mortgage Centric not Savings Centric

### DIFF
--- a/Services/Reports/ReportsService.cs
+++ b/Services/Reports/ReportsService.cs
@@ -300,22 +300,78 @@ public class ReportsService
     {
         var monthlyPayments = new List<MonthlyMortgagePayment>();
 
-        var currentSavingAmount = 0;
+        // Start from MortgageRequired = purchasePrice and iterate down to 0 using all cash available
 
-        while (currentSavingAmount < totalSavings)
+        // Base case, no savings used
+        var mortgageRequired = purchasePrice - equity;
+        var cashUsed = 0.0;
+
+        monthlyPayments.Add(new MonthlyMortgagePayment
         {
-            var deposit = equity + currentSavingAmount;
+            CashRequired = 0,
+            MonthlyPayment = _mortgagePaymentService.CalculateMonthlyMortgagePayment(mortgageRequired, interestRate, years),
+            MortgageRequired = mortgageRequired,
+            TotalDeposit = equity
+        });
+
+        // Round mortgage required to nearest £10,000
+        mortgageRequired = Math.Ceiling(mortgageRequired / 10000) * 10000;
+        cashUsed = purchasePrice - equity - mortgageRequired;
+
+        if (cashUsed < totalSavings && cashUsed > 0)
+        {
+            monthlyPayments.Add(new MonthlyMortgagePayment
+            {
+                CashRequired = cashUsed,
+                MonthlyPayment = _mortgagePaymentService.CalculateMonthlyMortgagePayment(mortgageRequired, interestRate, years),
+                MortgageRequired = mortgageRequired,
+                TotalDeposit = equity + cashUsed
+            });
+        }
+
+        while (cashUsed <= totalSavings)
+        {
+            mortgageRequired -= 10000;
+            cashUsed = purchasePrice - equity - mortgageRequired;
+
+            if (mortgageRequired < 0)
+            {
+                break;
+            }
+
+            if (cashUsed > totalSavings)
+            {
+                break;
+            }
 
             monthlyPayments.Add(new MonthlyMortgagePayment
             {
-                CashRequired = currentSavingAmount,
-                MonthlyPayment = _mortgagePaymentService.CalculateMonthlyMortgagePayment(purchasePrice - deposit, interestRate, years),
-                MortgageRequired = purchasePrice - deposit,
-                TotalDeposit = deposit
+                CashRequired = cashUsed,
+                MonthlyPayment = _mortgagePaymentService.CalculateMonthlyMortgagePayment(mortgageRequired, interestRate, years),
+                MortgageRequired = mortgageRequired,
+                TotalDeposit = equity + cashUsed
             });
-
-            currentSavingAmount += 10000;
         }
+
+        // for (var currentSavingAmount = 0; currentSavingAmount <= totalSavings; currentSavingAmount += 10000)
+        // {
+        //     var deposit = equity + currentSavingAmount;
+        //     var mortgageRequired = purchasePrice - deposit;
+
+        //     // Ensure MortgageRequired is not negative
+        //     if (mortgageRequired < 0)
+        //     {
+        //         break;
+        //     }
+
+        //     monthlyPayments.Add(new MonthlyMortgagePayment
+        //     {
+        //         CashRequired = currentSavingAmount,
+        //         MonthlyPayment = _mortgagePaymentService.CalculateMonthlyMortgagePayment(mortgageRequired, interestRate, years),
+        //         MortgageRequired = mortgageRequired,
+        //         TotalDeposit = deposit
+        //     });
+        // }
 
         return monthlyPayments;
     }

--- a/Services/Reports/ReportsService.cs
+++ b/Services/Reports/ReportsService.cs
@@ -304,8 +304,7 @@ public class ReportsService
 
         // Base case, no savings used
         var mortgageRequired = purchasePrice - equity;
-        var cashUsed = 0.0;
-
+        
         monthlyPayments.Add(new MonthlyMortgagePayment
         {
             CashRequired = 0,
@@ -316,7 +315,7 @@ public class ReportsService
 
         // Round mortgage required to nearest £10,000
         mortgageRequired = Math.Ceiling(mortgageRequired / 10000) * 10000;
-        cashUsed = purchasePrice - equity - mortgageRequired;
+        var cashUsed = purchasePrice - equity - mortgageRequired;
 
         if (cashUsed < totalSavings && cashUsed > 0)
         {
@@ -352,26 +351,6 @@ public class ReportsService
                 TotalDeposit = equity + cashUsed
             });
         }
-
-        // for (var currentSavingAmount = 0; currentSavingAmount <= totalSavings; currentSavingAmount += 10000)
-        // {
-        //     var deposit = equity + currentSavingAmount;
-        //     var mortgageRequired = purchasePrice - deposit;
-
-        //     // Ensure MortgageRequired is not negative
-        //     if (mortgageRequired < 0)
-        //     {
-        //         break;
-        //     }
-
-        //     monthlyPayments.Add(new MonthlyMortgagePayment
-        //     {
-        //         CashRequired = currentSavingAmount,
-        //         MonthlyPayment = _mortgagePaymentService.CalculateMonthlyMortgagePayment(mortgageRequired, interestRate, years),
-        //         MortgageRequired = mortgageRequired,
-        //         TotalDeposit = deposit
-        //     });
-        // }
 
         return monthlyPayments;
     }

--- a/Tests/Services.Tests/Reports/PropertyViabilityReportTests.cs
+++ b/Tests/Services.Tests/Reports/PropertyViabilityReportTests.cs
@@ -30,7 +30,7 @@ public class PropertyViabilityReportTests
         await _savingsService.CreateSavingsAccountAsync(ServiceTestsCommon.DefaultAccount.AccountId, new()
         {
             Name = "Test Savings",
-            InitialBalance = 15000,
+            InitialBalance = 55_000,
             SavingsRate = 3.0,
             SavingType = SavingType.ISA,
         });
@@ -39,8 +39,10 @@ public class PropertyViabilityReportTests
         var request = new PropertyViabilityReportRequest
         {
             CaseType = CaseType.BestCase,
-            CurrentPropertySalePrice = 0,
+            CurrentPropertySalePrice = 200_000,
             PurchasePrice = purchasePrice,
+            InterestRate = 4.1,
+            Years = 25,
         };
         _property = new Property
         {
@@ -77,5 +79,15 @@ public class PropertyViabilityReportTests
         var firstMortgagePayment = _viabilityReport.MonthlyMortgagePayments.First();
 
         Assert.That(firstMortgagePayment.MortgageRequired, Is.GreaterThan(0), "MortgageRequired is not set on MonthlyMortgagePayment.");
+    }
+
+    [Test]
+    public async Task GetPropertyViabilityReportAsync_MortgagePayments_MortgageRequired_IsDivisableBy10000()
+    {
+        Assert.That(_viabilityReport.MonthlyMortgagePayments, Has.Count.GreaterThanOrEqualTo(1), "No mortgage payments found on Property Viability Report.");
+
+        var mortgagePayment = _viabilityReport.MonthlyMortgagePayments[1];
+
+        Assert.That(mortgagePayment.MortgageRequired % 10000, Is.EqualTo(0), "MortgageRequired is not divisable by £10,000 on MonthlyMortgagePayment.");
     }
 }

--- a/Tests/Services.Tests/ServiceTestsCommon.cs
+++ b/Tests/Services.Tests/ServiceTestsCommon.cs
@@ -9,123 +9,122 @@ using ChrisUsher.MoveMate.Shared.DTOs.Properties;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 
-namespace Services.Tests
+namespace Services.Tests;
+
+public static class ServiceTestsCommon
 {
-    public static class ServiceTestsCommon
+    private static Faker _faker;
+    private static Account _account;
+    private static Property _currentProperty;
+    private static Property _purchaseProperty;
+    private static ServiceProvider _services;
+
+    public static IConfigurationRoot Configuration { get; internal set; }
+
+    public static Account DefaultAccount
     {
-        private static Faker _faker;
-        private static Account _account;
-        private static Property _currentProperty;
-        private static Property _purchaseProperty;
-        private static ServiceProvider _services;
-
-        public static IConfigurationRoot Configuration { get; internal set; }
-
-        public static Account DefaultAccount
+        get
         {
-            get
+            if (_account == null)
             {
-                if (_account == null)
-                {
-                    _account = Services.GetService<AccountService>()
-                        .CreateAccountAsync(new()
+                _account = Services.GetService<AccountService>()
+                    .CreateAccountAsync(new()
+                    {
+                        Email = Faker.Internet.Email()
+                    }).Result;
+            }
+            return _account;
+        }
+    }
+
+    public static Property DefaultCurrentProperty
+    {
+        get
+        {
+            if (_currentProperty == null)
+            {
+                _currentProperty = Services.GetService<PropertyService>()
+                    .CreatePropertyAsync(DefaultAccount.AccountId, new()
+                    {
+                        PropertyType = PropertyType.Current,
+                        Name = "Our House",
+                        MaxValue = 300_000,
+                        MinValue = 275_000,
+                        Equity = new()
                         {
-                            Email = Faker.Internet.Email()
-                        }).Result;
-                }
-                return _account;
+                            RemainingMortgage = 71_500,
+                            Updated = DateTime.UtcNow
+                        }
+                    }).Result;
             }
+            return _currentProperty;
         }
+    }
 
-        public static Property DefaultCurrentProperty
+    public static Property DefaultPurchaseProperty
+    {
+        get
         {
-            get
+            if (_purchaseProperty == null)
             {
-                if (_currentProperty == null)
-                {
-                    _currentProperty = Services.GetService<PropertyService>()
-                        .CreatePropertyAsync(DefaultAccount.AccountId, new()
-                        {
-                            PropertyType = PropertyType.Current,
-                            Name = "Our House",
-                            MaxValue = 300_000,
-                            MinValue = 275_000,
-                            Equity = new()
-                            {
-                                RemainingMortgage = 100_000,
-                                Updated = DateTime.UtcNow
-                            }
-                        }).Result;
-                }
-                return _currentProperty;
+                _purchaseProperty = Services.GetService<PropertyService>()
+                    .GetPropertiesAsync(DefaultAccount.AccountId, PropertyType.ToPurchase)
+                    .Result
+                    .First();
             }
+            return _purchaseProperty;
         }
+    }
 
-        public static Property DefaultPurchaseProperty
+    public static Faker Faker
+    {
+        get
         {
-            get
+            if (_faker == null)
             {
-                if (_purchaseProperty == null)
-                {
-                    _purchaseProperty = Services.GetService<PropertyService>()
-                        .GetPropertiesAsync(DefaultAccount.AccountId, PropertyType.ToPurchase)
-                        .Result
-                        .First();
-                }
-                return _purchaseProperty;
+                _faker = new Faker();
             }
+            return _faker;
         }
+    }
 
-        public static Faker Faker
+    public static ServiceProvider Services
+    {
+        get
         {
-            get
+            if (_services == null)
             {
-                if (_faker == null)
-                {
-                    _faker = new Faker();
-                }
-                return _faker;
+                _services = RegisterServicesAsync().Result;
             }
+            return _services;
         }
+    }
 
-        public static ServiceProvider Services
+    private static async Task<ServiceProvider> RegisterServicesAsync()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDbContext<DatabaseContext>(options =>
         {
-            get
-            {
-                if (_services == null)
-                {
-                    _services = RegisterServicesAsync().Result;
-                }
-                return _services;
-            }
-        }
+            options.UseMongoDB(Configuration.GetConnectionString("Database"), "movemate-test");
 
-        private static async Task<ServiceProvider> RegisterServicesAsync()
-        {
-            var services = new ServiceCollection();
-
-            services.AddDbContext<DatabaseContext>(options =>
-            {
-                options.UseMongoDB(Configuration.GetConnectionString("Database"), "movemate-test");
-
-                options.EnableSensitiveDataLogging();
+            options.EnableSensitiveDataLogging();
 
 #if DEBUG
 
-                options.EnableDetailedErrors();
-                options.LogTo(Console.WriteLine);
+            options.EnableDetailedErrors();
+            options.LogTo(Console.WriteLine);
 
 #endif
-            });
+        });
 
-            services.AddMoveMateServices(Configuration);
+        services.AddMoveMateServices(Configuration);
 
-            var serviceCollection = services.BuildServiceProvider();
+        var serviceCollection = services.BuildServiceProvider();
 
-            var blobServiceClient = serviceCollection.GetRequiredService<BlobServiceClient>();
-            await blobServiceClient.CreateBlobContainerAsync("outputcache");
+        var blobServiceClient = serviceCollection.GetRequiredService<BlobServiceClient>();
+        await blobServiceClient.CreateBlobContainerAsync("outputcache");
 
-            return serviceCollection;
-        }
+        return serviceCollection;
     }
 }


### PR DESCRIPTION
This pull request revises the mortgage payment calculation logic and updates related tests to ensure mortgage requirements are rounded to the nearest £10,000 and better reflect realistic scenarios. The changes also include minor code style improvements and updates to test data for consistency.

### Mortgage payment calculation logic

* Refactored the `CalculateMonthlyPayments` method in `ReportsService.cs` to round the mortgage required to the nearest £10,000, and iteratively decrease it in £10,000 steps, ensuring each calculated mortgage requirement is divisible by £10,000. The logic now starts from the maximum mortgage required and uses available savings more accurately.

### Test updates for mortgage calculations

* Added a new test in `PropertyViabilityReportTests.cs` to verify that each calculated mortgage requirement is divisible by £10,000, ensuring the business rule is enforced.
* Updated the test setup to use a higher initial savings balance (`55,000` instead of `15,000`) and set realistic property sale price, interest rate, and mortgage term values to better reflect actual scenarios. [[1]](diffhunk://#diff-ebe1922319d5564da68928a058fff511167aff452aa433291581f9fc86511c16L33-R33) [[2]](diffhunk://#diff-ebe1922319d5564da68928a058fff511167aff452aa433291581f9fc86511c16L42-R45)

### Test data and code style improvements

* Changed the default remaining mortgage value in `ServiceTestsCommon.cs` from `100,000` to `71,500` to align test data with updated scenarios.
* Updated the namespace declaration style in `ServiceTestsCommon.cs` to use file-scoped namespaces for cleaner code.
* Removed an unnecessary closing brace at the end of `ServiceTestsCommon.cs` for code style consistency.